### PR TITLE
test: Fix E2E test failure by updating button text assertion

### DIFF
--- a/e2e/home-landing.spec.ts
+++ b/e2e/home-landing.spec.ts
@@ -4,7 +4,7 @@ test('Home page renders all sections and links', async ({ page }) => {
   await page.goto('/')
 
   await expect(page.getByText('Masterpieces of Your Pet')).toBeVisible()
-  await expect(page.getByRole('link', { name: 'Explore Gallery' })).toBeVisible()
+  await expect(page.getByRole('link', { name: 'Create Your Art' })).toBeVisible()
 
   await expect(page.getByText('How it Works')).toBeVisible()
   await expect(page.getByText('Upload Photo')).toBeVisible()


### PR DESCRIPTION
## Summary
Fixed E2E test failure in `e2e/home-landing.spec.ts`.

## Changes
- Updated assertion to look for 'Create Your Art' button instead of 'Explore Gallery' link, reflecting the recent Hero component redesign.

## Verification
- `npx playwright test e2e/home-landing.spec.ts` passed locally.