### PR TITLE
Fix: stabilize product filters, notifications, and lint

### DIFF
--- a/docs/plans/2026-01-24-chatbot-auth-fix.md
+++ b/docs/plans/2026-01-24-chatbot-auth-fix.md
@@ -1,0 +1,33 @@
+# Auth Fix Design for Chatbot
+
+## Context
+The chatbot API (`/api/chat`) runs on the server but makes HTTP calls to other internal APIs (`/api/orders/status`, etc.) to fetch data.
+Currently, these internal calls fail with `401 Unauthorized` because the user's authentication cookies are not being forwarded from the chat request to the internal tool requests.
+
+## Approaches
+
+### Option 1: Header Forwarding (Recommended)
+Pass the `Cookie` header from the incoming chat request down to the tool execution functions.
+*   **Pros**: Simplest change, keeps existing Supabase Auth (Cookie) architecture, secure.
+*   **Cons**: Requires threading headers through the tool execution context.
+
+### Option 2: Server-Side Direct Call (Service Layer)
+Instead of tools calling `fetch('http://localhost:3000/api/...')`, they should call the Service functions directly (e.g., `getOrderById(...)`).
+*   **Pros**: Faster (no HTTP overhead), no auth/cookie issues (direct DB access via RLS client).
+*   **Cons**: Tighter coupling, but actually cleaner for a monolith Next.js app.
+
+### Option 3: Switch to Explicit JWT
+Change the entire app to use Bearer tokens.
+*   **Pros**: Standard for mobile/external consumers.
+*   **Cons**: Massive refactor of frontend and backend, unnecessary for this stage.
+
+## Recommendation: Option 2 (Service Layer Direct Call)
+Since we are in a Next.js server environment (Route Handler), calling our own API endpoints via HTTP is actually an anti-pattern ("Serverless calling Serverless"). It introduces latency and auth complexity.
+
+**We should modify `src/lib/ai/tools.ts` to call the `src/services/*.ts` functions directly.**
+This automatically solves the Auth problem because we can pass the `supabase` client (initialized with the user's cookies) directly to the service functions.
+
+## Plan
+1.  Modify `src/app/api/chat/route.ts` to initialize a `supabase` client using `createServerClient()`.
+2.  Pass this authenticated client to the `ToolLoopAgent` or context.
+3.  Refactor `src/lib/ai/tools.ts` to accept a Supabase client and call Services instead of `fetch`.

--- a/docs/plans/2026-01-24-notification-system-design.md
+++ b/docs/plans/2026-01-24-notification-system-design.md
@@ -1,0 +1,63 @@
+# Price Alert Notification System Design
+
+## Overview
+This document outlines the architecture for "real" user notifications when product prices drop or stock status changes. The system will detect changes and deliver notifications via **In-App Notifications** (Phase 1) and **Email** (Phase 2).
+
+## 1. Change Detection Architecture
+How do we know when to send a notification?
+
+### Option A: Event-Driven (Recommended for MVP)
+Trigger checks immediately when an Admin updates a product.
+*   **Flow**: Admin API updates product -> `afterUpdate` hook -> Check `product_alerts` table -> Create notification.
+*   **Pros**: Real-time, simple.
+*   **Cons**: Adds latency to admin operations.
+
+### Option B: Polling / Cron Job
+A scheduled job runs every hour to check all active alerts against current prices.
+*   **Pros**: Decoupled, robust against burst updates.
+*   **Cons**: Not real-time (up to 1 hour delay), requires Cron infrastructure (Vercel Cron / Supabase pg_cron).
+
+### Option C: Database Triggers (Supabase Specific)
+Use PostgreSQL triggers + Supabase Edge Functions.
+*   **Flow**: DB Row Updated -> Trigger -> Edge Function -> Send Email.
+*   **Pros**: Highly scalable, zero impact on app server.
+*   **Cons**: Logic lives outside the main codebase (in SQL/Edge Functions), harder to debug.
+
+**Recommendation**: **Option A (Event-Driven)** via a Service Layer wrapper. Since we already have a `src/services` layer, we can wrap the product update logic to trigger alerts asynchronously.
+
+## 2. Notification Delivery (Phase 1: In-App)
+
+### Data Model
+New table: `notifications`
+*   `id`: uuid
+*   `user_id`: uuid (recipient)
+*   `type`: 'price_alert' | 'system'
+*   `title`: string
+*   `message`: string
+*   `read`: boolean (default false)
+*   `created_at`: timestamp
+*   `metadata`: jsonb (e.g., `{ product_id: "...", old_price: 100, new_price: 80 }`)
+
+### UX
+*   **Navbar**: Bell icon with unread badge count.
+*   **Dropdown**: List of recent notifications.
+*   **Click**: Marks as read and redirects to product page.
+
+## 3. Implementation Plan
+
+1.  **Database**: Create `notifications` table with RLS.
+2.  **Service**:
+    *   `createNotification(userId, ...)`
+    *   `checkAlertsForProduct(productId, newPrice)`: Finds matching alerts and creates notifications.
+3.  **Integration**:
+    *   Modify `updateProduct` (admin function) to call `checkAlertsForProduct`.
+4.  **UI**:
+    *   Add `NotificationBell` component to Navbar.
+    *   Add API route `/api/notifications` for polling/fetching.
+
+## 4. Future Expansion (Email)
+Once the `checkAlertsForProduct` logic is in place, adding Email is trivial: just add a `sendEmail(...)` call alongside `createNotification`.
+
+---
+
+**Next Step**: Should I proceed with creating the `notifications` table and the service logic?

--- a/src/app/api/alerts/route.ts
+++ b/src/app/api/alerts/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { createServerClient } from '@/lib/supabase-server'
+import { createAlert, getUserAlerts } from '@/services/alerts'
 import { z } from 'zod'
 
 const CreateAlertSchema = z.object({
@@ -7,21 +8,6 @@ const CreateAlertSchema = z.object({
   productId: z.string().uuid(),
   targetPrice: z.number().optional(),
 })
-
-// Mock alerts store since we haven't created the table yet
-// In a real app, this would be a Supabase table 'product_alerts'
-// id, user_id, product_id, type, target_price, created_at
-interface MockAlert {
-  id: string
-  userId: string
-  productId: string
-  type: string
-  targetPrice?: number
-  createdAt: string
-  active: boolean
-}
-
-const MOCK_ALERTS_STORE: MockAlert[] = []
 
 export async function GET(req: Request) {
   void req
@@ -35,12 +21,11 @@ export async function GET(req: Request) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
-    // In real app: select * from product_alerts where user_id = user.id
-    const userAlerts = MOCK_ALERTS_STORE.filter(a => a.userId === user.id)
-    return NextResponse.json(userAlerts)
-  } catch (error) {
+    const alerts = await getUserAlerts(user.id, supabase)
+    return NextResponse.json(alerts)
+  } catch (error: any) {
     console.error('GET /api/alerts error', error)
-    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 })
+    return NextResponse.json({ error: error.message || 'Internal Server Error' }, { status: 500 })
   }
 }
 
@@ -64,22 +49,12 @@ export async function POST(req: Request) {
 
     const { type, productId, targetPrice } = result.data
 
-    const newAlert: MockAlert = {
-      id: crypto.randomUUID(),
-      userId: user.id,
-      productId,
-      type,
-      targetPrice,
-      createdAt: new Date().toISOString(),
-      active: true
-    }
-
-    MOCK_ALERTS_STORE.push(newAlert)
+    const newAlert = await createAlert(user.id, productId, type, targetPrice, supabase)
 
     return NextResponse.json(newAlert)
-  } catch (error) {
+  } catch (error: any) {
     console.error('POST /api/alerts error', error)
-    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 })
+    return NextResponse.json({ error: error.message || 'Internal Server Error' }, { status: 500 })
   }
 }
 
@@ -101,15 +76,17 @@ export async function DELETE(req: Request) {
       return NextResponse.json({ error: 'Missing id' }, { status: 400 })
     }
 
-    const index = MOCK_ALERTS_STORE.findIndex(a => a.id === id && a.userId === user.id)
-    if (index !== -1) {
-      MOCK_ALERTS_STORE.splice(index, 1)
-      return NextResponse.json({ success: true })
-    }
+    const { error } = await supabase
+        .from('product_alerts')
+        .delete()
+        .eq('id', id)
+        .eq('user_id', user.id) // Ensure ownership
 
-    return NextResponse.json({ error: 'Alert not found' }, { status: 404 })
-  } catch (error) {
+    if (error) throw error
+
+    return NextResponse.json({ success: true })
+  } catch (error: any) {
     console.error('DELETE /api/alerts error', error)
-    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 })
+    return NextResponse.json({ error: error.message || 'Internal Server Error' }, { status: 500 })
   }
 }

--- a/src/app/api/alerts/route.ts
+++ b/src/app/api/alerts/route.ts
@@ -9,8 +9,7 @@ const CreateAlertSchema = z.object({
   targetPrice: z.number().optional(),
 })
 
-export async function GET(req: Request) {
-  void req
+export async function GET() {
   try {
     const supabase = await createServerClient()
     const {
@@ -23,9 +22,10 @@ export async function GET(req: Request) {
 
     const alerts = await getUserAlerts(user.id, supabase)
     return NextResponse.json(alerts)
-  } catch (error: any) {
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Internal Server Error'
     console.error('GET /api/alerts error', error)
-    return NextResponse.json({ error: error.message || 'Internal Server Error' }, { status: 500 })
+    return NextResponse.json({ error: message }, { status: 500 })
   }
 }
 
@@ -52,9 +52,10 @@ export async function POST(req: Request) {
     const newAlert = await createAlert(user.id, productId, type, targetPrice, supabase)
 
     return NextResponse.json(newAlert)
-  } catch (error: any) {
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Internal Server Error'
     console.error('POST /api/alerts error', error)
-    return NextResponse.json({ error: error.message || 'Internal Server Error' }, { status: 500 })
+    return NextResponse.json({ error: message }, { status: 500 })
   }
 }
 
@@ -85,8 +86,9 @@ export async function DELETE(req: Request) {
     if (error) throw error
 
     return NextResponse.json({ success: true })
-  } catch (error: any) {
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Internal Server Error'
     console.error('DELETE /api/alerts error', error)
-    return NextResponse.json({ error: error.message || 'Internal Server Error' }, { status: 500 })
+    return NextResponse.json({ error: message }, { status: 500 })
   }
 }

--- a/src/app/api/chat/route.toolcall.test.ts
+++ b/src/app/api/chat/route.toolcall.test.ts
@@ -7,6 +7,14 @@ vi.mock('@/lib/ai/openai', () => ({
   },
 }));
 
+vi.mock('@/lib/supabase-server', () => ({
+  createServerClient: vi.fn(async () => ({
+    auth: {
+      getUser: vi.fn().mockResolvedValue({ data: { user: null }, error: null }),
+    },
+  })),
+}));
+
 vi.mock('@/lib/ai/tools', () => ({
   searchProducts: {
     description: 'mock search',
@@ -20,6 +28,11 @@ vi.mock('@/lib/ai/tools', () => ({
   },
   checkReturnEligibility: {
     description: 'mock return',
+    parameters: {},
+    execute: vi.fn(),
+  },
+  createReturnTicket: {
+    description: 'mock return ticket',
     parameters: {},
     execute: vi.fn(),
   },

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -2,10 +2,12 @@ import { randomUUID } from 'crypto';
 import { openai } from '@/lib/ai/openai';
 import { ToolLoopAgent, createAgentUIStreamResponse, stepCountIs, type UIMessage } from 'ai';
 import { SYSTEM_PROMPT } from '@/lib/ai/prompts';
+import { createServerClient } from '@/lib/supabase-server';
 import {
   searchProducts,
   trackOrder,
   checkReturnEligibility,
+  createReturnTicket,
   createAlert,
   listUserOrders,
 } from '@/lib/ai/tools';
@@ -41,6 +43,28 @@ export async function POST(req: Request) {
 
   console.log('Sending messages to model:', JSON.stringify(normalizedMessages, null, 2));
 
+  // 1. Initialize Supabase client with cookies
+  const supabase = await createServerClient();
+  
+  // 2. Get current user
+  const { data: { user } } = await supabase.auth.getUser();
+  
+  let role = 'customer';
+  if (user) {
+    const { data: profile } = await supabase
+      .from('profiles')
+      .select('role')
+      .eq('id', user.id)
+      .single();
+    role = profile?.role || 'customer';
+  }
+
+  // 3. Prepare context
+  const toolContext = {
+    supabase,
+    user: user ? { id: user.id, role } : null
+  };
+
   const agent = new ToolLoopAgent({
     model: openai.chat(process.env.AI_MODEL_NAME || 'deepseek-ai/DeepSeek-V3'),
     instructions: SYSTEM_PROMPT,
@@ -51,15 +75,60 @@ export async function POST(req: Request) {
       searchProducts,
       trackOrder,
       checkReturnEligibility,
+      createReturnTicket,
       createAlert,
       listUserOrders,
     },
+    // Inject context into all tool executions
+    // @ts-ignore - The AI SDK types might not strictly support this, but it works at runtime or via custom adapter logic if we were using it.
+    // WAIT: ToolLoopAgent from 'ai' package doesn't support 'context' property directly in constructor for tool execution.
+    // We need to check how Vercel AI SDK handles context injection.
+    // Actually, the `tools` definitions are static.
+    // The `execute` function receives `options`. We need to pass context there.
+    // But `ToolLoopAgent` doesn't seem to expose a way to pass per-request context to tools easily.
+    
+    // CORRECT APPROACH: 
+    // We need to wrap the tools to inject context, OR use the `experimental_tool` with context if available.
+    // However, since we defined tools using `tool()`, we can't easily curry them here without losing type inference?
+    // Actually, we can just mutate the options object if we had access to the runner...
+    
+    // Let's use a wrapper function for tools or rebuild the agent options.
+  });
+
+  // WORKAROUND: Since we can't pass context directly to ToolLoopAgent constructor to be forwarded to tools (it's not in the standard API),
+  // We need to re-bind the tools with context.
+  
+  const toolsWithContext = {
+    searchProducts, // Doesn't need context
+    trackOrder: { ...trackOrder, execute: (args: any, options: any) => trackOrder.execute!(args, { ...options, context: toolContext }) },
+    checkReturnEligibility: { ...checkReturnEligibility, execute: (args: any, options: any) => checkReturnEligibility.execute!(args, { ...options, context: toolContext }) },
+    createReturnTicket: { ...createReturnTicket, execute: (args: any, options: any) => createReturnTicket.execute!(args, { ...options, context: toolContext }) },
+    createAlert: { ...createAlert, execute: (args: any, options: any) => createAlert.execute!(args, { ...options, context: toolContext }) },
+    listUserOrders: { ...listUserOrders, execute: (args: any, options: any) => listUserOrders.execute!(args, { ...options, context: toolContext }) },
+  };
+
+  // Re-create agent with bound tools
+  const boundAgent = new ToolLoopAgent({
+    model: openai.chat(process.env.AI_MODEL_NAME || 'deepseek-ai/DeepSeek-V3'),
+    instructions: SYSTEM_PROMPT,
+    temperature: 0,
+    toolChoice: 'auto',
+    stopWhen: stepCountIs(5),
+    tools: toolsWithContext,
   });
 
   return createAgentUIStreamResponse({
-    agent,
+    agent: boundAgent,
     uiMessages: normalizedMessages,
     onStepFinish: (step) => {
+      // DEBUG LOGGING
+      if (step.toolCalls && step.toolCalls.length > 0) {
+        console.log('[Chatbot Debug] Tool Calls:', JSON.stringify(step.toolCalls, null, 2));
+      }
+      if (step.toolResults && step.toolResults.length > 0) {
+        console.log('[Chatbot Debug] Tool Results:', JSON.stringify(step.toolResults, null, 2));
+      }
+
       // Ensure tool results surface as UI parts for frontend cards.
       const hasToolResults = step.toolResults && step.toolResults.length > 0;
       if (!hasToolResults) return;

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from 'next/server'
+import { createServerClient } from '@/lib/supabase-server'
+
+export async function GET(req: Request) {
+  try {
+    const supabase = await createServerClient()
+    const { data: { user } } = await supabase.auth.getUser()
+
+    if (!user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const { data: notifications, error } = await supabase
+      .from('notifications')
+      .select('*')
+      .eq('user_id', user.id)
+      .order('created_at', { ascending: false })
+      .limit(20)
+
+    if (error) throw error
+
+    return NextResponse.json(notifications)
+  } catch (error: any) {
+    console.error('GET /api/notifications error', error)
+    return NextResponse.json({ error: error.message || 'Internal Server Error' }, { status: 500 })
+  }
+}
+
+export async function PATCH(req: Request) {
+  try {
+    const supabase = await createServerClient()
+    const { data: { user } } = await supabase.auth.getUser()
+
+    if (!user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const body = await req.json()
+    const { id, read } = body
+
+    if (!id) {
+      return NextResponse.json({ error: 'Missing id' }, { status: 400 })
+    }
+
+    const { error } = await supabase
+      .from('notifications')
+      .update({ read: read ?? true })
+      .eq('id', id)
+      .eq('user_id', user.id)
+
+    if (error) throw error
+
+    return NextResponse.json({ success: true })
+  } catch (error: any) {
+    console.error('PATCH /api/notifications error', error)
+    return NextResponse.json({ error: error.message || 'Internal Server Error' }, { status: 500 })
+  }
+}

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { createServerClient } from '@/lib/supabase-server'
 
-export async function GET(req: Request) {
+export async function GET() {
   try {
     const supabase = await createServerClient()
     const { data: { user } } = await supabase.auth.getUser()
@@ -20,9 +20,10 @@ export async function GET(req: Request) {
     if (error) throw error
 
     return NextResponse.json(notifications)
-  } catch (error: any) {
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Internal Server Error'
     console.error('GET /api/notifications error', error)
-    return NextResponse.json({ error: error.message || 'Internal Server Error' }, { status: 500 })
+    return NextResponse.json({ error: message }, { status: 500 })
   }
 }
 
@@ -51,8 +52,9 @@ export async function PATCH(req: Request) {
     if (error) throw error
 
     return NextResponse.json({ success: true })
-  } catch (error: any) {
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Internal Server Error'
     console.error('PATCH /api/notifications error', error)
-    return NextResponse.json({ error: error.message || 'Internal Server Error' }, { status: 500 })
+    return NextResponse.json({ error: message }, { status: 500 })
   }
 }

--- a/src/app/api/orders/eligibility/route.ts
+++ b/src/app/api/orders/eligibility/route.ts
@@ -34,8 +34,9 @@ export async function POST(req: Request) {
       },
       daysSincePurchase: result.daysSincePurchase,
     })
-  } catch (error: any) {
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Internal Server Error'
     console.error('[orders/eligibility] error', error)
-    return NextResponse.json({ error: error.message || 'Internal Server Error' }, { status: 500 })
+    return NextResponse.json({ error: message }, { status: 500 })
   }
 }

--- a/src/app/api/orders/eligibility/route.ts
+++ b/src/app/api/orders/eligibility/route.ts
@@ -1,30 +1,6 @@
 import { NextResponse } from 'next/server'
 import { createServerClient } from '@/lib/supabase-server'
-import { getOrderById } from '@/services/orders'
-
-const RETURN_WINDOW_DAYS = 30
-
-function daysBetween(from: string) {
-  const fromDate = new Date(from)
-  const now = new Date()
-  const diffMs = now.getTime() - fromDate.getTime()
-  return Math.floor(diffMs / (1000 * 60 * 60 * 24))
-}
-
-function buildEligibility(orderDate: string, status: string) {
-  const days = daysBetween(orderDate)
-  const withinWindow = days <= RETURN_WINDOW_DAYS
-  const statusAllowed = status !== 'cancelled'
-
-  const eligible = withinWindow && statusAllowed
-  const reason = eligible
-    ? `Eligible: within ${RETURN_WINDOW_DAYS} days of purchase.`
-    : !statusAllowed
-      ? 'Ineligible: order was cancelled.'
-      : `Ineligible: beyond ${RETURN_WINDOW_DAYS}-day return window.`
-
-  return { eligible, reason, daysSincePurchase: days }
-}
+import { checkReturnEligibility } from '@/services/returns'
 
 export async function POST(req: Request) {
   try {
@@ -44,38 +20,22 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
-    const { data: profile } = await supabase
-      .from('profiles')
-      .select('role')
-      .eq('id', user.id)
-      .single()
-
-    const role = profile?.role || 'customer'
-
-    const order = await getOrderById(orderId, supabase)
-    if (!order) {
-      return NextResponse.json({ error: 'Order not found' }, { status: 404 })
-    }
-
-    if (role !== 'admin' && order.userId !== user.id) {
-      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-    }
-
-    const { eligible, reason, daysSincePurchase } = buildEligibility(order.createdAt, order.status)
+    // Pass the supabase server client to the service so it can query DB
+    const result = await checkReturnEligibility(orderId, user.id, supabase)
 
     return NextResponse.json({
-      orderId: order.id,
-      eligible,
-      reason,
+      orderId,
+      eligible: result.eligible,
+      reason: result.reason,
+      existingReturnId: result.existingReturnId,
       policy: {
-        windowDays: RETURN_WINDOW_DAYS,
+        windowDays: 30,
         notes: 'Items must be unused and in original packaging. Final sale items excluded.',
       },
-      daysSincePurchase,
-      orderStatus: order.status,
+      daysSincePurchase: result.daysSincePurchase,
     })
-  } catch (error) {
+  } catch (error: any) {
     console.error('[orders/eligibility] error', error)
-    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 })
+    return NextResponse.json({ error: error.message || 'Internal Server Error' }, { status: 500 })
   }
 }

--- a/src/app/api/returns/create/route.ts
+++ b/src/app/api/returns/create/route.ts
@@ -31,8 +31,9 @@ export async function POST(req: Request) {
     const returnRequest = await createReturnRequest(orderId, user.id, reason, supabase)
 
     return NextResponse.json(returnRequest)
-  } catch (error: any) {
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Internal Server Error'
     console.error('POST /api/returns/create error', error)
-    return NextResponse.json({ error: error.message || 'Internal Server Error' }, { status: 500 })
+    return NextResponse.json({ error: message }, { status: 500 })
   }
 }

--- a/src/app/api/returns/create/route.ts
+++ b/src/app/api/returns/create/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server'
+import { createServerClient } from '@/lib/supabase-server'
+import { createReturnRequest } from '@/services/returns'
+import { z } from 'zod'
+
+const CreateReturnSchema = z.object({
+  orderId: z.string().uuid(),
+  reason: z.string().min(1, "Reason is required"),
+})
+
+export async function POST(req: Request) {
+  try {
+    const supabase = await createServerClient()
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+
+    if (!user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const body = await req.json().catch(() => null)
+    const result = CreateReturnSchema.safeParse(body)
+
+    if (!result.success) {
+      return NextResponse.json({ error: 'Invalid input', details: result.error }, { status: 400 })
+    }
+
+    const { orderId, reason } = result.data
+
+    const returnRequest = await createReturnRequest(orderId, user.id, reason, supabase)
+
+    return NextResponse.json(returnRequest)
+  } catch (error: any) {
+    console.error('POST /api/returns/create error', error)
+    return NextResponse.json({ error: error.message || 'Internal Server Error' }, { status: 500 })
+  }
+}

--- a/src/components/ai/cards/AlertCard.tsx
+++ b/src/components/ai/cards/AlertCard.tsx
@@ -1,13 +1,34 @@
-import { Bell, Check } from 'lucide-react';
+import { Bell, Check, AlertCircle } from 'lucide-react';
 
 interface AlertData {
   id: string;
   type: 'price_drop' | 'restock';
   targetPrice?: number;
   message: string;
+  error?: string;
 }
 
 export function AlertCard({ data }: { data: AlertData }) {
+  if (data.error) {
+    return (
+      <div className="bg-red-50 rounded-xl border border-red-200 shadow-sm overflow-hidden text-sm">
+        <div className="p-4 flex items-center gap-3">
+          <div className="w-10 h-10 rounded-full bg-red-100 text-red-600 flex items-center justify-center shrink-0">
+            <AlertCircle className="w-5 h-5" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <span className="font-semibold text-red-800 text-xs uppercase tracking-wider block mb-1">
+              Failed to Set Alert
+            </span>
+            <p className="text-red-600 font-medium">
+              {data.error}
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="bg-white rounded-xl border border-blue-100 shadow-sm overflow-hidden text-sm bg-gradient-to-br from-blue-50 to-white">
       <div className="p-4 flex items-center gap-3">

--- a/src/components/ai/cards/OrderCard.tsx
+++ b/src/components/ai/cards/OrderCard.tsx
@@ -15,6 +15,15 @@ interface OrderData {
 }
 
 export function OrderCard({ data }: { data: OrderData }) {
+  // Defensive programming: Handle undefined/missing data gracefully
+  if (!data || !data.orderId) {
+    return (
+      <div className="bg-red-50 text-red-600 p-3 rounded-lg text-sm border border-red-200">
+        Error: Invalid order data received
+      </div>
+    )
+  }
+
   return (
     <div className="bg-white rounded-xl border border-stone-200 shadow-sm overflow-hidden text-sm">
       {/* Header */}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -6,6 +6,7 @@ import { cookies } from 'next/headers'
 import { User, LogOut } from 'lucide-react'
 import { logout } from '@/app/(shop)/login/actions'
 import { MobileNav } from './MobileNav'
+import { NotificationBell } from '@/components/ui/NotificationBell'
 
 export async function Header() {
   const cookieStore = await cookies()
@@ -68,6 +69,9 @@ export async function Header() {
                 >
                   Admin
                 </Link>
+                <div className="flex items-center gap-2">
+                  <NotificationBell />
+                </div>
                 <div className="flex items-center gap-2 text-sm text-muted-foreground border-l pl-4 border-stone-200">
                   <User className="w-4 h-4" />
                   <span className="hidden sm:inline font-medium max-w-[150px] truncate">{user.email}</span>

--- a/src/components/orders/OrderDetail.tsx
+++ b/src/components/orders/OrderDetail.tsx
@@ -17,6 +17,19 @@ interface OrderDetailProps {
   initialOrder?: Order | null
 }
 
+
+function FormattedDate({ date }: { date: string }) {
+  const [formatted, setFormatted] = useState<string>('')
+
+  useEffect(() => {
+    setFormatted(new Date(date).toLocaleString())
+  }, [date])
+
+  if (!formatted) return <span>Loading...</span>
+
+  return <span>{formatted}</span>
+}
+
 export function OrderDetail({ orderId, initialOrder }: OrderDetailProps) {
   const router = useRouter()
   const [order, setOrder] = useState<Order | null>(initialOrder || null)
@@ -190,11 +203,11 @@ export function OrderDetail({ orderId, initialOrder }: OrderDetailProps) {
             <div className="p-4 space-y-2 text-sm text-slate-600">
               <div className="flex justify-between">
                 <span>下单时间</span>
-                <span>{new Date(order.createdAt).toLocaleString()}</span>
+                <FormattedDate date={order.createdAt} />
               </div>
               <div className="flex justify-between">
                 <span>最近更新</span>
-                <span>{new Date(order.updatedAt).toLocaleString()}</span>
+                <FormattedDate date={order.updatedAt} />
               </div>
             </div>
           </div>

--- a/src/components/orders/OrderDetail.tsx
+++ b/src/components/orders/OrderDetail.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import Link from 'next/link'
 import Image from 'next/image'
 import { useRouter } from 'next/navigation'
@@ -19,14 +19,7 @@ interface OrderDetailProps {
 
 
 function FormattedDate({ date }: { date: string }) {
-  const [formatted, setFormatted] = useState<string>('')
-
-  useEffect(() => {
-    setFormatted(new Date(date).toLocaleString())
-  }, [date])
-
-  if (!formatted) return <span>Loading...</span>
-
+  const formatted = useMemo(() => new Date(date).toLocaleString(), [date])
   return <span>{formatted}</span>
 }
 

--- a/src/components/products/ProductFilterBar.tsx
+++ b/src/components/products/ProductFilterBar.tsx
@@ -15,7 +15,12 @@ export function ProductFilterBar({ onFilterChange, initialFilter }: ProductFilte
   const [sort, setSort] = useState<ProductFilter['sort']>(initialFilter?.sort || 'newest')
   
   const isMounted = useRef(false)
+  const onFilterChangeRef = useRef(onFilterChange)
   const debouncedQuery = useDebounce(query, 300)
+
+  useEffect(() => {
+    onFilterChangeRef.current = onFilterChange
+  }, [onFilterChange])
 
   // Unified filter change handler
   useEffect(() => {
@@ -23,8 +28,8 @@ export function ProductFilterBar({ onFilterChange, initialFilter }: ProductFilte
       isMounted.current = true
       return
     }
-    onFilterChange({ query: debouncedQuery, category, sort })
-  }, [debouncedQuery, category, sort, onFilterChange])
+    onFilterChangeRef.current({ query: debouncedQuery, category, sort })
+  }, [debouncedQuery, category, sort])
 
   return (
     <div className="flex flex-col sm:flex-row gap-4 mb-6 p-4 bg-white rounded-lg shadow-sm border border-gray-100">

--- a/src/components/ui/NotificationBell.tsx
+++ b/src/components/ui/NotificationBell.tsx
@@ -1,0 +1,155 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import { Bell, Check } from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import { createClientComponentClient } from '@/lib/supabase'
+import { Notification } from '@/services/notifications'
+import Link from 'next/link'
+
+export function NotificationBell() {
+  const [isOpen, setIsOpen] = useState(false)
+  const [notifications, setNotifications] = useState<Notification[]>([])
+  const [unreadCount, setUnreadCount] = useState(0)
+  const supabase = createClientComponentClient()
+  const dropdownRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    // 1. Initial fetch
+    fetchNotifications()
+
+    // 2. Realtime subscription
+    const channel = supabase
+      .channel('notifications')
+      .on(
+        'postgres_changes',
+        {
+          event: 'INSERT',
+          schema: 'public',
+          table: 'notifications',
+        },
+        (payload: { new: any }) => {
+          // Add new notification to list
+          const newNotification = payload.new as Notification
+          setNotifications(prev => [newNotification, ...prev])
+          setUnreadCount(prev => prev + 1)
+        }
+      )
+      .subscribe()
+
+    return () => {
+      supabase.removeChannel(channel)
+    }
+  }, [supabase])
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [])
+
+  const fetchNotifications = async () => {
+    try {
+      const res = await fetch('/api/notifications')
+      if (res.ok) {
+        const data = await res.json()
+        setNotifications(data)
+        setUnreadCount(data.filter((n: Notification) => !n.read).length)
+      }
+    } catch (e) {
+      console.error('Failed to fetch notifications', e)
+    }
+  }
+
+  const markAsRead = async (id: string) => {
+    // Optimistic update
+    setNotifications(prev => prev.map(n => n.id === id ? { ...n, read: true } : n))
+    setUnreadCount(prev => Math.max(0, prev - 1))
+
+    try {
+      await fetch('/api/notifications', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id, read: true })
+      })
+    } catch (e) {
+      console.error('Failed to mark as read', e)
+    }
+  }
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      <Button
+        variant="ghost"
+        // size="icon" - removed because existing Button component might not support it
+        className="relative text-stone-500 hover:text-stone-900 w-10 h-10 p-0 rounded-full"
+        onClick={() => setIsOpen(!isOpen)}
+      >
+        <Bell className="w-5 h-5" />
+        {unreadCount > 0 && (
+          <span className="absolute top-1.5 right-1.5 w-2 h-2 bg-red-500 rounded-full border border-white" />
+        )}
+      </Button>
+
+      {isOpen && (
+        <div className="absolute right-0 mt-2 w-80 bg-white rounded-xl shadow-xl border border-stone-200 overflow-hidden z-50 animate-in fade-in zoom-in-95 duration-100 origin-top-right">
+          <div className="p-3 border-b border-stone-100 flex justify-between items-center bg-stone-50/50">
+            <h3 className="font-semibold text-sm text-stone-900">Notifications</h3>
+            {unreadCount > 0 && (
+              <span className="text-xs bg-stone-100 text-stone-600 px-2 py-0.5 rounded-full">
+                {unreadCount} new
+              </span>
+            )}
+          </div>
+          
+          <div className="max-h-[400px] overflow-y-auto">
+            {notifications.length === 0 ? (
+              <div className="p-8 text-center text-stone-500 text-sm">
+                <Bell className="w-8 h-8 mx-auto mb-2 text-stone-300" />
+                <p>No notifications yet</p>
+              </div>
+            ) : (
+              <div className="divide-y divide-stone-100">
+                {notifications.map((notification) => (
+                  <div 
+                    key={notification.id}
+                    className={`p-3 hover:bg-stone-50 transition-colors flex gap-3 ${!notification.read ? 'bg-blue-50/30' : ''}`}
+                  >
+                    <div className={`mt-1 w-2 h-2 rounded-full shrink-0 ${!notification.read ? 'bg-blue-500' : 'bg-transparent'}`} />
+                    <div className="flex-1 min-w-0">
+                      <div className="flex justify-between items-start mb-0.5">
+                        <h4 className={`text-sm ${!notification.read ? 'font-semibold text-stone-900' : 'font-medium text-stone-700'}`}>
+                          {notification.title}
+                        </h4>
+                        {!notification.read && (
+                          <button 
+                            onClick={() => markAsRead(notification.id)}
+                            className="text-stone-400 hover:text-blue-600 p-1 -mt-1 -mr-1"
+                            title="Mark as read"
+                          >
+                            <Check className="w-3 h-3" />
+                          </button>
+                        )}
+                      </div>
+                      <p className="text-xs text-stone-500 line-clamp-2 leading-relaxed">
+                        {notification.message}
+                      </p>
+                      <div className="mt-1.5 text-[10px] text-stone-400">
+                        {new Date(notification.createdAt).toLocaleDateString()}
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/lib/ai/prompts.ts
+++ b/src/lib/ai/prompts.ts
@@ -26,12 +26,19 @@ CAPABILITIES:
   - Do NOT call 'searchProducts' for support intents (returns, order issues, eligibility, tracking, alerts) unless the user explicitly asks for new products.
   - After using 'searchProducts', provide a short summary of the products found and complete the reply (never stop at tool calls).
   - If no products match, say none were found and suggest refining keywords/budget.
-- Returns/order support rules:
-  - If the user wants to return or has an order issue and no orderId is provided, first call 'listUserOrders' to show recent orders and let them pick one.
-  - Do NOT recommend products in returns/order-support flows unless the user switches back to shopping.
+  - Returns/order support rules:
+    - If the user wants to return or has an order issue and no orderId is provided, first call 'listUserOrders' to show recent orders and let them pick one.
+    - Do NOT recommend products in returns/order-support flows unless the user switches back to shopping.
+
+  - Alerts & Notifications rules:
+    - You can create alerts for 'price_drop' or 'restock' using 'createAlert'.
+    - For 'price_drop' alerts:
+      - If user specifies a target price (e.g., "under $100"), use that value.
+      - If user just says "alert me of price drops" WITHOUT specifying a target, pass NO targetPrice value - the system will automatically use the current product price as the target. Do NOT ask the user for a target price.
+    - For 'restock' alerts, no targetPrice needed.
 
 RESPONSE FORMAT:
-- Keep responses short (under 3 sentences when possible).
+  - Keep responses short (under 3 sentences when possible).
 - When showing products, the UI will render them as cards, so you don't need to list every detail in text. Just introduce them.
 
 REMINDER: Your primary and ONLY purpose is to assist with PetPixel e-commerce tasks. Do not engage in general philosophy, coding, or unrelated roleplay.

--- a/src/lib/ai/tools.ts
+++ b/src/lib/ai/tools.ts
@@ -1,6 +1,20 @@
 import { z } from 'zod';
 import { tool, type Tool, type ToolExecutionOptions } from 'ai';
-import { createClient } from '@supabase/supabase-js';
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { getOrderById, getOrders, getUserOrders } from '@/services/orders';
+import { checkReturnEligibility as checkEligibilityService, createReturnRequest } from '@/services/returns';
+import { createAlert as createAlertService } from '@/services/alerts';
+import { Order, OrderItemView } from '@/types/order';
+
+type ToolContext = {
+  supabase: SupabaseClient;
+  user: { id: string; role?: string } | null;
+}
+
+// Extension to AI SDK type since we are injecting context
+type ContextAwareToolExecutionOptions = ToolExecutionOptions & {
+  context?: ToolContext;
+};
 
 const ProductSchema = z.object({
   id: z.string(),
@@ -22,30 +36,53 @@ export const trackOrderSchema = z.object({
 export const trackOrder = tool({
   description: 'Get the status and timeline of a specific order',
   inputSchema: trackOrderSchema,
-  execute: async ({ orderId }) => {
+  execute: async ({ orderId }, options) => {
     try {
-      const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
-      const res = await fetch(`${baseUrl}/api/orders/status?orderId=${orderId}`, {
-        method: 'GET',
-      });
-      
-      if (res.ok) {
-        return await res.json();
+      const context = (options as ContextAwareToolExecutionOptions).context;
+      if (!context?.supabase || !context?.user) {
+        return { error: 'Unauthorized: Please login to track orders.' };
       }
+
+      // Direct service call instead of fetch
+      const order = await getOrderById(orderId, context.supabase);
+      
+      if (!order) {
+        return { error: 'Order not found' };
+      }
+
+      // Security check (redundant if RLS works, but good practice)
+      if (context.user.role !== 'admin' && order.userId !== context.user.id) {
+        return { error: 'Unauthorized: You can only view your own orders.' };
+      }
+
+      // Construct timeline (logic copied from status/route.ts)
+      const events = [
+        { label: 'Order Created', status: 'created', timestamp: order.createdAt },
+      ];
+
+      if (order.status === 'paid' || order.status === 'shipped') {
+        events.push({ label: 'Payment Confirmed', status: 'paid', timestamp: order.updatedAt });
+      }
+
+      if (order.status === 'shipped') {
+        events.push({ label: 'Shipped', status: 'shipped', timestamp: order.updatedAt });
+      }
+
+      if (order.status === 'cancelled') {
+        events.push({ label: 'Cancelled', status: 'cancelled', timestamp: order.updatedAt });
+      }
+
+      return {
+        orderId: order.id,
+        status: order.status,
+        total: order.total,
+        shippingAddress: order.shippingAddress,
+        timeline: events,
+      };
     } catch (e) {
       console.error('Track order tool error', e);
+      return { error: 'System error while tracking order' };
     }
-
-    return {
-      orderId,
-      status: 'shipped',
-      total: 120,
-      shippingAddress: { city: 'Demo City' },
-      timeline: [
-        { label: 'Ordered', status: 'completed', date: new Date().toISOString() },
-        { label: 'Shipped', status: 'current', date: new Date().toISOString() },
-      ]
-    };
   },
 });
 
@@ -56,28 +93,60 @@ export const checkReturnEligibilitySchema = z.object({
 export const checkReturnEligibility = tool({
   description: 'Check if an order is eligible for return or exchange',
   inputSchema: checkReturnEligibilitySchema,
-  execute: async ({ orderId }) => {
+  execute: async ({ orderId }, options) => {
     try {
-      const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
-      const res = await fetch(`${baseUrl}/api/orders/eligibility`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ orderId }),
-      });
-      
-      if (res.ok) {
-        return await res.json();
+      const context = (options as ContextAwareToolExecutionOptions).context;
+      if (!context?.supabase || !context?.user) {
+        return { error: 'Unauthorized' };
       }
-    } catch (e) {
-      console.error('Return eligibility tool error', e);
-    }
 
-    return {
-      orderId,
-      eligible: true,
-      reason: 'Within 30 days window',
-      policy: { windowDays: 30 }
-    };
+      const result = await checkEligibilityService(orderId, context.user.id, context.supabase);
+
+      return {
+        orderId,
+        eligible: result.eligible,
+        reason: result.reason,
+        existingReturnId: result.existingReturnId,
+        policy: { windowDays: 30 },
+        daysSincePurchase: result.daysSincePurchase
+      };
+    } catch (e: any) {
+      console.error('Return eligibility tool error', e);
+      return { 
+        orderId,
+        eligible: false,
+        reason: e.message || 'Could not verify eligibility (System Error)',
+        policy: { windowDays: 30 }
+      };
+    }
+  },
+});
+
+export const createReturnTicketSchema = z.object({
+  orderId: z.string().describe('The Order ID to create a return ticket for'),
+  reason: z.string().describe('Reason for the return'),
+});
+
+export const createReturnTicket = tool({
+  description: 'Create a return ticket (request) for an eligible order',
+  inputSchema: createReturnTicketSchema,
+  execute: async ({ orderId, reason }, options) => {
+    try {
+      const context = (options as ContextAwareToolExecutionOptions).context;
+      if (!context?.supabase || !context?.user) {
+        return { error: 'Unauthorized' };
+      }
+
+      const returnRequest = await createReturnRequest(orderId, context.user.id, reason, context.supabase);
+      
+      return {
+         ...returnRequest,
+         message: 'Return ticket created successfully. Support will review it shortly.'
+      };
+    } catch (e: any) {
+      console.error('Create return ticket tool error', e);
+      return { error: e.message || 'Failed to create return ticket' };
+    }
   },
 });
 
@@ -90,34 +159,23 @@ export const createAlertSchema = z.object({
 export const createAlert = tool({
   description: 'Create a price drop or restock alert for a product',
   inputSchema: createAlertSchema,
-  execute: async ({ productId, type, targetPrice }) => {
+  execute: async ({ productId, type, targetPrice }, options) => {
     try {
-      const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
-      const res = await fetch(`${baseUrl}/api/alerts`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ productId, type, targetPrice }),
-      });
-      
-      if (res.ok) {
-        const data = await res.json();
-        return {
-          ...data,
-          message: 'Alert created successfully'
-        };
+      const context = (options as ContextAwareToolExecutionOptions).context;
+      if (!context?.supabase || !context?.user) {
+        return { error: 'Unauthorized' };
       }
-    } catch (e) {
-      console.error('Create alert tool error', e);
-    }
 
-    return {
-      id: `alert-${Math.random().toString(36).substr(2, 9)}`,
-      productId,
-      type,
-      targetPrice,
-      active: true,
-      message: 'Alert created successfully'
-    };
+      const newAlert = await createAlertService(context.user.id, productId, type, targetPrice, context.supabase);
+
+      return {
+        ...newAlert,
+        message: 'Alert created successfully'
+      };
+    } catch (e: any) {
+      console.error('Create alert tool error', e);
+      return { error: e.message || 'System error while creating alert' };
+    }
   },
 });
 
@@ -128,42 +186,44 @@ export const listUserOrdersSchema = z.object({
 export const listUserOrders = tool({
   description: 'List the most recent orders for the authenticated user (or admin)',
   inputSchema: listUserOrdersSchema,
-  execute: async ({ limit }) => {
+  execute: async ({ limit }, options) => {
     try {
-      const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
-      const url = new URL(`${baseUrl}/api/orders/list`);
-      if (limit) {
-        url.searchParams.set('limit', String(limit));
+      const context = (options as ContextAwareToolExecutionOptions).context;
+      if (!context?.supabase || !context?.user) {
+        return { error: 'Unauthorized' };
       }
 
-      const res = await fetch(url.toString(), {
-        method: 'GET',
-        credentials: 'include',
-      });
+      // Use getUserOrders instead of getOrders to respect RBAC for customers
+      // getOrders is strict admin-only
+      const orders = await getUserOrders(
+        context.user.id, 
+        context.user.role || 'customer', 
+        context.supabase
+      );
 
-      if (res.ok) {
-        return await res.json();
-      }
+      // Filter logic is inside getOrders service, but we might need to limit count manually if service doesn't support limit param
+      // Note: getOrders service returns ALL orders. We should slice it.
+      const limitedOrders = orders.slice(0, limit || 5);
+
+      const formatted = limitedOrders.map((order: Order) => ({
+        orderId: order.id,
+        shortId: order.id.slice(0, 8),
+        createdAt: order.createdAt,
+        status: order.status,
+        total: order.total,
+        items: (order.items || []).slice(0, 2).map((item: OrderItemView) => ({
+          id: item.id,
+          name: item.product?.name ?? 'Unknown item',
+          imageUrl: item.product?.image_url ?? '',
+          quantity: item.quantity,
+        })),
+      }));
+
+      return { orders: formatted };
     } catch (e) {
       console.error('List user orders tool error', e);
+      return { error: 'System error while listing orders' };
     }
-
-    const now = new Date();
-    return {
-      orders: [
-        {
-          orderId: 'demo-order-1',
-          shortId: 'demo-1',
-          createdAt: now.toISOString(),
-          status: 'shipped',
-          total: 120,
-          items: [
-            { id: 'item-1', name: 'Canvas Tote', imageUrl: '', quantity: 1 },
-            { id: 'item-2', name: 'Oil Brush Set', imageUrl: '', quantity: 2 },
-          ],
-        },
-      ],
-    };
   },
 });
 
@@ -208,28 +268,6 @@ const fallbackProducts = [
   },
 ];
 
-const filterFallback = (query?: string, maxPrice?: number) => {
-  let result = fallbackProducts;
-  if (typeof maxPrice === 'number') {
-    result = result.filter((p) => p.price <= maxPrice);
-  }
-  if (query && query.trim()) {
-    const q = query.trim().toLowerCase();
-    result = result.filter(
-      (p) => p.name.toLowerCase().includes(q) || p.description.toLowerCase().includes(q),
-    );
-  }
-  if (result.length === 0 && typeof maxPrice === 'number') {
-    // If query filter removed all, retry with price-only filter
-    result = fallbackProducts.filter((p) => p.price <= maxPrice);
-  }
-  if (result.length === 0) {
-    // If still empty, return all fallback
-    result = fallbackProducts;
-  }
-  return result.slice(0, 5);
-};
-
 export const searchParamsSchema = z.object({
   query: z.string().describe('Keywords to search for in product name or description'),
   category: z.string().optional().describe('Product category (e.g., Oil, Watercolor, Pop Art)'),
@@ -250,15 +288,17 @@ export const searchProducts = tool({
 
     console.log('Searching products:', { query: safeQuery, category, maxPrice: safeMaxPrice });
 
-    // If Supabase not configured, or query empty, always use fallback
-    if (!supabase || !safeQuery) {
-      return filterFallback(safeQuery, safeMaxPrice);
+    // If Supabase not configured, or query empty, return empty
+    if (!supabase) {
+      return [];
     }
 
     let dbQuery = supabase.from('products').select('*');
     
     // Simple keyword search on name or description
-    dbQuery = dbQuery.or(`name.ilike.%${safeQuery}%,description.ilike.%${safeQuery}%`);
+    if (safeQuery) {
+        dbQuery = dbQuery.or(`name.ilike.%${safeQuery}%,description.ilike.%${safeQuery}%`);
+    }
 
     if (category) {
       dbQuery = dbQuery.ilike('category', `%${category}%`);
@@ -271,11 +311,11 @@ export const searchProducts = tool({
     
     if (error) {
       console.error('Supabase search error:', error);
-      return filterFallback(safeQuery, safeMaxPrice);
+      return [];
     }
 
     if (!data || data.length === 0) {
-      return filterFallback(safeQuery, safeMaxPrice);
+      return [];
     }
 
     const parsed = ProductSchema.array().safeParse(data);
@@ -283,7 +323,7 @@ export const searchProducts = tool({
       return parsed.data;
     }
 
-    console.warn('Product schema validation failed, using fallback');
-    return filterFallback(safeQuery, safeMaxPrice);
+    console.warn('Product schema validation failed');
+    return [];
   },
 }) as Tool<z.infer<typeof searchParamsSchema>, z.infer<typeof ProductSchema>[]>;

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -37,6 +37,32 @@ export type Database = {
         Insert: Omit<Database['public']['Tables']['products']['Row'], 'id' | 'created_at'>
         Update: Partial<Database['public']['Tables']['products']['Insert']>
       }
+      returns: {
+        Row: {
+          id: string
+          order_id: string
+          user_id: string
+          status: 'requested' | 'approved' | 'rejected' | 'completed'
+          reason: string
+          created_at: string
+          updated_at: string
+        }
+        Insert: Omit<Database['public']['Tables']['returns']['Row'], 'id' | 'created_at' | 'updated_at'>
+        Update: Partial<Database['public']['Tables']['returns']['Insert']>
+      }
+      product_alerts: {
+        Row: {
+          id: string
+          user_id: string
+          product_id: string
+          type: 'price_drop' | 'restock'
+          target_price: number | null
+          status: 'active' | 'triggered' | 'cancelled'
+          created_at: string
+        }
+        Insert: Omit<Database['public']['Tables']['product_alerts']['Row'], 'id' | 'created_at'>
+        Update: Partial<Database['public']['Tables']['product_alerts']['Insert']>
+      }
     }
   }
 }

--- a/src/services/alerts.test.ts
+++ b/src/services/alerts.test.ts
@@ -1,0 +1,93 @@
+import { describe, test, expect, vi } from 'vitest'
+import { createAlert, getUserAlerts } from './alerts'
+
+const mockAlertData = {
+  id: 'alert-1',
+  user_id: 'user-1',
+  product_id: 'prod-1',
+  type: 'price_drop',
+  target_price: 100,
+  status: 'active',
+  created_at: new Date().toISOString()
+}
+
+// Mock chain helper
+const createQueryChain = (returnData: any) => {
+  const chain: any = {}
+  chain.select = vi.fn(() => chain)
+  chain.insert = vi.fn(() => chain)
+  chain.eq = vi.fn(() => chain)
+  chain.order = vi.fn(() => chain)
+  chain.single = vi.fn(() => Promise.resolve({ data: returnData, error: null }))
+  chain.then = (onfulfilled: any) => Promise.resolve({ data: returnData, error: null }).then(onfulfilled)
+  return chain
+}
+
+const mockSupabase = {
+  from: vi.fn(() => createQueryChain(mockAlertData))
+}
+
+describe('Alerts Service', () => {
+  test('createAlert inserts and returns alert', async () => {
+    // @ts-ignore
+    const alert = await createAlert('user-1', 'prod-1', 'price_drop', 100, mockSupabase)
+    
+    expect(mockSupabase.from).toHaveBeenCalledWith('product_alerts')
+    expect(alert.id).toBe('alert-1')
+    expect(alert.targetPrice).toBe(100)
+  })
+
+  test('price_drop alert without targetPrice uses current product price', async () => {
+    const product = { id: 'prod-1', price: 150 }
+    
+    // Mock for product lookup
+    const productQuery: any = {}
+    productQuery.select = vi.fn(() => productQuery)
+    productQuery.eq = vi.fn(() => productQuery)
+    productQuery.single = vi.fn().mockResolvedValue({ data: product, error: null })
+    
+    // Mock for alert insert
+    const alertInsert: any = {}
+    alertInsert.insert = vi.fn(() => alertInsert)
+    alertInsert.select = vi.fn(() => alertInsert)
+    alertInsert.single = vi.fn().mockResolvedValue({ 
+      data: { ...mockAlertData, target_price: 150 }, 
+      error: null 
+    })
+    
+    const mockClient = {
+      from: vi.fn((table) => {
+        if (table === 'products') return productQuery
+        if (table === 'product_alerts') return alertInsert
+        return {}
+      })
+    }
+    
+    // @ts-ignore - Call without targetPrice
+    const alert = await createAlert('user-1', 'prod-1', 'price_drop', undefined, mockClient)
+    
+    expect(alertInsert.insert).toHaveBeenCalledWith(
+      expect.objectContaining({ target_price: 150 })
+    )
+    expect(alert.targetPrice).toBe(150)
+  })
+
+  test('getUserAlerts fetches alerts for user', async () => {
+    const mockList = [mockAlertData, { ...mockAlertData, id: 'alert-2' }]
+    const listClient = {
+      from: vi.fn(() => {
+        const chain: any = {}
+        chain.select = vi.fn(() => chain)
+        chain.eq = vi.fn(() => chain)
+        chain.order = vi.fn(() => Promise.resolve({ data: mockList, error: null }))
+        return chain
+      })
+    }
+
+    // @ts-ignore
+    const alerts = await getUserAlerts('user-1', listClient)
+    
+    expect(listClient.from).toHaveBeenCalledWith('product_alerts')
+    expect(alerts).toHaveLength(2)
+  })
+})

--- a/src/services/alerts.ts
+++ b/src/services/alerts.ts
@@ -1,0 +1,72 @@
+import { supabase } from '@/lib/supabase'
+import { SupabaseClient } from '@supabase/supabase-js'
+import type { DatabaseAlert, ProductAlert, AlertType } from '@/types/alert'
+
+export async function createAlert(
+  userId: string,
+  productId: string,
+  type: AlertType,
+  targetPrice?: number,
+  client: SupabaseClient = supabase
+): Promise<ProductAlert> {
+  // 1. Verify product exists and get current price
+  const { data: product, error: productError } = await client
+    .from('products')
+    .select('id, price')
+    .eq('id', productId)
+    .single()
+
+  if (productError || !product) {
+    throw new Error('Product not found')
+  }
+
+  // 2. If targetPrice not provided for price_drop, use current price
+  const finalTargetPrice = (type === 'price_drop' && targetPrice === undefined)
+    ? product.price
+    : targetPrice
+
+  const { data, error } = await client
+    .from('product_alerts')
+    .insert({
+      user_id: userId,
+      product_id: productId,
+      type,
+      target_price: finalTargetPrice,
+      status: 'active'
+    })
+    .select()
+    .single()
+
+  if (error) throw error
+  if (!data) throw new Error('Failed to create alert')
+
+  return mapToFrontendAlert(data)
+}
+
+export async function getUserAlerts(
+  userId: string,
+  client: SupabaseClient = supabase
+): Promise<ProductAlert[]> {
+  const { data, error } = await client
+    .from('product_alerts')
+    .select('*')
+    .eq('user_id', userId)
+    .order('created_at', { ascending: false })
+
+  if (error) throw error
+  if (!data) return []
+
+  return data.map(mapToFrontendAlert)
+}
+
+function mapToFrontendAlert(row: DatabaseAlert): ProductAlert {
+  return {
+    id: row.id,
+    userId: row.user_id,
+    productId: row.product_id,
+    type: row.type,
+    targetPrice: row.target_price ?? undefined,
+    status: row.status,
+    createdAt: row.created_at
+  }
+}

--- a/src/services/notifications.test.ts
+++ b/src/services/notifications.test.ts
@@ -1,0 +1,123 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { checkAlertsForProduct } from './notifications'
+
+// Mock dependencies
+const mockSupabase = {
+  from: vi.fn(),
+}
+
+describe('checkAlertsForProduct', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // Helper to setup mock chain
+  const setupMockAlerts = (alerts: any[]) => {
+    const builder: any = {}
+    builder.select = vi.fn(() => builder)
+    builder.eq = vi.fn(() => builder)
+    builder.update = vi.fn(() => builder)
+    builder.in = vi.fn(() => builder)
+    builder.then = (resolve: any) => Promise.resolve({ data: alerts, error: null }).then(resolve)
+    
+    mockSupabase.from.mockImplementation((table) => {
+      if (table === 'product_alerts') return builder
+      if (table === 'notifications') return { insert: vi.fn().mockResolvedValue({ error: null }) }
+      return {}
+    })
+    
+    return builder
+  }
+
+  test('should trigger price_drop alert when price is below target', async () => {
+    const alerts = [{
+      id: 'alert-1',
+      user_id: 'user-1',
+      type: 'price_drop',
+      target_price: 100,
+      status: 'active'
+    }]
+    
+    const builder = setupMockAlerts(alerts)
+    const insertNotificationMock = vi.fn().mockResolvedValue({ error: null })
+    mockSupabase.from.mockImplementation((table) => {
+      if (table === 'product_alerts') return builder
+      if (table === 'notifications') return { insert: insertNotificationMock }
+      return {}
+    })
+
+    // Act
+    // @ts-ignore
+    await checkAlertsForProduct('prod-1', 90, 10, mockSupabase, 'price_drop')
+
+    // Assert
+    expect(insertNotificationMock).toHaveBeenCalled()
+    expect(builder.eq).toHaveBeenCalledWith('type', 'price_drop')
+  })
+
+  test('should NOT trigger price_drop alert if price is above target', async () => {
+    const alerts = [{
+      id: 'alert-1',
+      user_id: 'user-1',
+      type: 'price_drop',
+      target_price: 80,
+      status: 'active'
+    }]
+    
+    const builder = setupMockAlerts(alerts)
+    const insertNotificationMock = vi.fn().mockResolvedValue({ error: null })
+    mockSupabase.from.mockImplementation((table) => {
+        if (table === 'product_alerts') return builder
+        if (table === 'notifications') return { insert: insertNotificationMock }
+        return {}
+    })
+
+    // Act
+    // @ts-ignore
+    await checkAlertsForProduct('prod-1', 90, 10, mockSupabase, 'price_drop')
+
+    // Assert
+    expect(insertNotificationMock).not.toHaveBeenCalled()
+  })
+
+  test('should NOT trigger restock alert when only checking price drop', async () => {
+    const alerts = [{
+      id: 'alert-restock',
+      user_id: 'user-2',
+      type: 'restock',
+      status: 'active'
+    }]
+
+    const builder: any = {}
+    builder.select = vi.fn(() => builder)
+    builder.update = vi.fn(() => builder)
+    builder.in = vi.fn(() => builder)
+    
+    const filters: Record<string, any> = {}
+    builder.eq = vi.fn((col, val) => {
+        filters[col] = val
+        return builder
+    })
+    
+    builder.then = (resolve: any) => {
+        let result = alerts
+        if (filters['type'] && filters['type'] !== 'restock') {
+            result = []
+        }
+        return Promise.resolve({ data: result, error: null }).then(resolve)
+    }
+
+    const insertNotificationMock = vi.fn().mockResolvedValue({ error: null })
+    mockSupabase.from.mockImplementation((table) => {
+      if (table === 'product_alerts') return builder
+      if (table === 'notifications') return { insert: insertNotificationMock }
+      return {}
+    })
+
+    // @ts-ignore
+    await checkAlertsForProduct('prod-1', 90, 10, mockSupabase, 'price_drop')
+
+    expect(builder.eq).toHaveBeenCalledWith('type', 'price_drop')
+    expect(insertNotificationMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/services/notifications.ts
+++ b/src/services/notifications.ts
@@ -8,7 +8,7 @@ export interface Notification {
   title: string
   message: string
   read: boolean
-  metadata: Record<string, any>
+  metadata: Record<string, unknown>
   createdAt: string
 }
 
@@ -17,7 +17,7 @@ export async function createNotification(
   type: Notification['type'],
   title: string,
   message: string,
-  metadata: Record<string, any> = {},
+  metadata: Record<string, unknown> = {},
   client: SupabaseClient = supabase
 ) {
   const { error } = await client.from('notifications').insert({
@@ -57,8 +57,14 @@ export async function checkAlertsForProduct(
 
   if (error || !alerts) return
 
-  const notificationsToCreate = []
-  const alertsToUpdate = []
+  const notificationsToCreate: {
+    user_id: string
+    type: Notification['type']
+    title: string
+    message: string
+    metadata: Record<string, unknown>
+  }[] = []
+  const alertsToUpdate: string[] = []
 
   for (const alert of alerts) {
     let shouldNotify = false

--- a/src/services/notifications.ts
+++ b/src/services/notifications.ts
@@ -1,0 +1,114 @@
+import { supabase } from '@/lib/supabase'
+import { SupabaseClient } from '@supabase/supabase-js'
+
+export interface Notification {
+  id: string
+  userId: string
+  type: 'price_drop' | 'restock' | 'system'
+  title: string
+  message: string
+  read: boolean
+  metadata: Record<string, any>
+  createdAt: string
+}
+
+export async function createNotification(
+  userId: string,
+  type: Notification['type'],
+  title: string,
+  message: string,
+  metadata: Record<string, any> = {},
+  client: SupabaseClient = supabase
+) {
+  const { error } = await client.from('notifications').insert({
+    user_id: userId,
+    type,
+    title,
+    message,
+    metadata,
+    read: false
+  })
+
+  if (error) {
+    console.error('Failed to create notification:', error)
+    throw error
+  }
+}
+
+export async function checkAlertsForProduct(
+  productId: string,
+  newPrice: number,
+  newStock: number,
+  client: SupabaseClient = supabase,
+  limitType?: Notification['type']
+) {
+  // 1. Fetch active alerts for this product
+  let query = client
+    .from('product_alerts')
+    .select('*')
+    .eq('product_id', productId)
+    .eq('status', 'active')
+
+  if (limitType) {
+    query = query.eq('type', limitType)
+  }
+
+  const { data: alerts, error } = await query
+
+  if (error || !alerts) return
+
+  const notificationsToCreate = []
+  const alertsToUpdate = []
+
+  for (const alert of alerts) {
+    let shouldNotify = false
+    let title = ''
+    let message = ''
+
+    // Force numeric comparison
+    const price = Number(newPrice)
+    const stock = Number(newStock)
+    const targetPrice = alert.target_price ? Number(alert.target_price) : null
+
+    // Check Price Drop
+    if (alert.type === 'price_drop' && targetPrice !== null) {
+      if (price <= targetPrice) {
+        shouldNotify = true
+        title = 'Price Drop Alert!'
+        message = `Good news! A product you're watching has dropped to $${price}.`
+      }
+    } 
+    // Check Restock
+    else if (alert.type === 'restock') {
+      if (stock > 0) {
+        shouldNotify = true
+        title = 'Restock Alert!'
+        message = `A product you're watching is back in stock.`
+      }
+    }
+
+    if (shouldNotify) {
+      notificationsToCreate.push({
+        user_id: alert.user_id,
+        type: alert.type,
+        title,
+        message,
+        metadata: { product_id: productId, alert_id: alert.id, triggered_price: price }
+      })
+      
+      alertsToUpdate.push(alert.id)
+    }
+  }
+
+  // 2. Batch create notifications
+  if (notificationsToCreate.length > 0) {
+    await client.from('notifications').insert(notificationsToCreate)
+    
+    // 3. Mark alerts as triggered (optional, or keep active?)
+    // Usually price alerts are one-time unless recurring. Let's mark triggered.
+    await client
+      .from('product_alerts')
+      .update({ status: 'triggered' })
+      .in('id', alertsToUpdate)
+  }
+}

--- a/src/services/returns.test.ts
+++ b/src/services/returns.test.ts
@@ -22,7 +22,7 @@ describe('Returns Service', () => {
   })
 
   test('checkReturnEligibility returns eligible for recent shipped order', async () => {
-    // @ts-ignore
+    // @ts-expect-error mock getOrderById typing loosened in test
     vi.mocked(getOrderById).mockResolvedValue(mockOrder)
 
     // Mock returns check (empty)
@@ -36,7 +36,7 @@ describe('Returns Service', () => {
       }))
     }
 
-    // @ts-ignore
+    // @ts-expect-error mock client is loosely typed
     const result = await checkReturnEligibility('order-1', 'user-1', mockClient)
     
     expect(result.eligible).toBe(true)
@@ -54,7 +54,7 @@ describe('Returns Service', () => {
       }))
     }
 
-    // @ts-ignore
+    // @ts-expect-error mock client is loosely typed
     const result = await checkReturnEligibility('order-1', 'user-1', mockClient)
     
     expect(result.eligible).toBe(false)

--- a/src/services/returns.test.ts
+++ b/src/services/returns.test.ts
@@ -1,0 +1,63 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { checkReturnEligibility } from './returns'
+
+// Mock getOrderById dependency
+vi.mock('@/services/orders', () => ({
+  getOrderById: vi.fn()
+}))
+
+import { getOrderById } from '@/services/orders'
+
+const mockOrder = {
+  id: 'order-1',
+  userId: 'user-1',
+  status: 'shipped',
+  createdAt: new Date().toISOString(), // Today
+  items: []
+}
+
+describe('Returns Service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('checkReturnEligibility returns eligible for recent shipped order', async () => {
+    // @ts-ignore
+    vi.mocked(getOrderById).mockResolvedValue(mockOrder)
+
+    // Mock returns check (empty)
+    const mockClient = {
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            neq: vi.fn(() => Promise.resolve({ data: [], error: null }))
+          }))
+        }))
+      }))
+    }
+
+    // @ts-ignore
+    const result = await checkReturnEligibility('order-1', 'user-1', mockClient)
+    
+    expect(result.eligible).toBe(true)
+    expect(result.daysSincePurchase).toBe(0)
+  })
+
+  test('checkReturnEligibility fails if return already exists', async () => {
+    const mockClient = {
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            neq: vi.fn(() => Promise.resolve({ data: [{ id: 'ret-1', status: 'requested' }], error: null }))
+          }))
+        }))
+      }))
+    }
+
+    // @ts-ignore
+    const result = await checkReturnEligibility('order-1', 'user-1', mockClient)
+    
+    expect(result.eligible).toBe(false)
+    expect(result.existingReturnId).toBe('ret-1')
+  })
+})

--- a/src/services/returns.ts
+++ b/src/services/returns.ts
@@ -1,0 +1,114 @@
+import { supabase } from '@/lib/supabase'
+import { SupabaseClient } from '@supabase/supabase-js'
+import { getOrderById } from '@/services/orders'
+import type { DatabaseReturn, ReturnRequest } from '@/types/return'
+
+const RETURN_WINDOW_DAYS = 30
+
+export interface EligibilityResult {
+  eligible: boolean
+  reason: string
+  daysSincePurchase: number
+  existingReturnId?: string
+}
+
+export async function checkReturnEligibility(
+  orderId: string,
+  userId: string,
+  client: SupabaseClient = supabase
+): Promise<EligibilityResult> {
+  // 1. Check if return already exists
+  const { data: existingReturns } = await client
+    .from('returns')
+    .select('id, status')
+    .eq('order_id', orderId)
+    .neq('status', 'cancelled') // Active returns block new ones
+
+  if (existingReturns && existingReturns.length > 0) {
+    return {
+      eligible: false,
+      reason: `A return request (ID: ${existingReturns[0].id}) already exists for this order.`,
+      daysSincePurchase: 0,
+      existingReturnId: existingReturns[0].id
+    }
+  }
+
+  // 2. Check order details
+  const order = await getOrderById(orderId, client)
+  if (!order) {
+    throw new Error('Order not found')
+  }
+
+  // 3. Verify ownership (if not verified by RLS/caller context)
+  if (order.userId !== userId) {
+    // We assume the caller (API route) handles auth, but good to be safe.
+    // However, if called by admin, this check might be annoying.
+    // For now, relies on the `client` having correct permissions via RLS.
+  }
+
+  const fromDate = new Date(order.createdAt)
+  const now = new Date()
+  const diffMs = now.getTime() - fromDate.getTime()
+  const days = Math.floor(diffMs / (1000 * 60 * 60 * 24))
+
+  const withinWindow = days <= RETURN_WINDOW_DAYS
+  
+  let reason = ''
+  let eligible = true
+
+  if (!withinWindow) {
+    eligible = false
+    reason = `Ineligible: beyond ${RETURN_WINDOW_DAYS}-day return window.`
+  } else if (order.status === 'cancelled') {
+    eligible = false
+    reason = 'Ineligible: order was cancelled.'
+  } else if (order.status === 'pending') {
+    eligible = false
+    reason = 'Ineligible: order is not yet paid/shipped.'
+  } else {
+    reason = `Eligible: within ${RETURN_WINDOW_DAYS} days.`
+  }
+
+  return { eligible, reason, daysSincePurchase: days }
+}
+
+export async function createReturnRequest(
+  orderId: string,
+  userId: string,
+  reason: string,
+  client: SupabaseClient = supabase
+): Promise<ReturnRequest> {
+  // Check eligibility first
+  const eligibility = await checkReturnEligibility(orderId, userId, client)
+  if (!eligibility.eligible) {
+    throw new Error(eligibility.reason)
+  }
+
+  const { data, error } = await client
+    .from('returns')
+    .insert({
+      order_id: orderId,
+      user_id: userId,
+      reason: reason,
+      status: 'requested'
+    })
+    .select()
+    .single()
+
+  if (error) throw error
+  if (!data) throw new Error('Failed to create return')
+
+  return mapToFrontendReturn(data)
+}
+
+function mapToFrontendReturn(row: DatabaseReturn): ReturnRequest {
+  return {
+    id: row.id,
+    orderId: row.order_id,
+    userId: row.user_id,
+    status: row.status,
+    reason: row.reason,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at
+  }
+}

--- a/src/types/alert.ts
+++ b/src/types/alert.ts
@@ -1,0 +1,24 @@
+export type AlertType = 'price_drop' | 'restock'
+export type AlertStatus = 'active' | 'triggered' | 'cancelled'
+
+// Database structure (matches 'product_alerts' table)
+export interface DatabaseAlert {
+  id: string
+  user_id: string
+  product_id: string
+  type: AlertType
+  target_price: number | null
+  status: AlertStatus
+  created_at: string
+}
+
+// Frontend view model
+export interface ProductAlert {
+  id: string
+  userId: string
+  productId: string
+  type: AlertType
+  targetPrice?: number
+  status: AlertStatus
+  createdAt: string
+}

--- a/src/types/return.ts
+++ b/src/types/return.ts
@@ -1,0 +1,23 @@
+export type ReturnStatus = 'requested' | 'approved' | 'rejected' | 'completed'
+
+// Database structure (matches 'returns' table)
+export interface DatabaseReturn {
+  id: string
+  order_id: string
+  user_id: string
+  status: ReturnStatus
+  reason: string
+  created_at: string
+  updated_at: string
+}
+
+// Frontend view model
+export interface ReturnRequest {
+  id: string
+  orderId: string
+  userId: string
+  status: ReturnStatus
+  reason: string
+  createdAt: string
+  updatedAt: string
+}

--- a/supabase/migrations/20260124_chatbot_features.sql
+++ b/supabase/migrations/20260124_chatbot_features.sql
@@ -1,0 +1,90 @@
+-- Create returns table
+create table returns (
+  id uuid default gen_random_uuid() primary key,
+  order_id uuid references orders on delete cascade not null,
+  user_id uuid references auth.users on delete cascade not null,
+  status text default 'requested' check (status in ('requested', 'approved', 'rejected', 'completed')),
+  reason text not null,
+  created_at timestamp with time zone default timezone('utc'::text, now()) not null,
+  updated_at timestamp with time zone default timezone('utc'::text, now()) not null
+);
+
+-- Create product_alerts table
+create table product_alerts (
+  id uuid default gen_random_uuid() primary key,
+  user_id uuid references auth.users on delete cascade not null,
+  product_id uuid references products on delete cascade not null,
+  type text not null check (type in ('price_drop', 'restock')),
+  target_price numeric(10,2),
+  status text default 'active' check (status in ('active', 'triggered', 'cancelled')),
+  created_at timestamp with time zone default timezone('utc'::text, now()) not null
+);
+
+-- Enable RLS
+alter table returns enable row level security;
+alter table product_alerts enable row level security;
+
+-- RLS Policies for returns
+
+-- Users can view their own returns
+create policy "Users can view own returns"
+  on returns for select
+  using (auth.uid() = user_id);
+
+-- Users can create their own returns
+create policy "Users can create own returns"
+  on returns for insert
+  with check (auth.uid() = user_id);
+
+-- Admins can view all returns
+create policy "Admins can view all returns"
+  on returns for select
+  using (
+    exists (
+      select 1 from profiles
+      where profiles.id = auth.uid()
+      and profiles.role = 'admin'
+    )
+  );
+
+-- Admins can update returns
+create policy "Admins can update returns"
+  on returns for update
+  using (
+    exists (
+      select 1 from profiles
+      where profiles.id = auth.uid()
+      and profiles.role = 'admin'
+    )
+  );
+
+-- RLS Policies for product_alerts
+
+-- Users can view/manage their own alerts
+create policy "Users can view own alerts"
+  on product_alerts for select
+  using (auth.uid() = user_id);
+
+create policy "Users can create own alerts"
+  on product_alerts for insert
+  with check (auth.uid() = user_id);
+
+create policy "Users can update own alerts"
+  on product_alerts for update
+  using (auth.uid() = user_id);
+
+create policy "Users can delete own alerts"
+  on product_alerts for delete
+  using (auth.uid() = user_id);
+
+-- Indexes
+create index returns_user_id_idx on returns(user_id);
+create index returns_order_id_idx on returns(order_id);
+create index product_alerts_user_id_idx on product_alerts(user_id);
+create index product_alerts_product_id_idx on product_alerts(product_id);
+
+-- Trigger for updated_at on returns
+create trigger update_returns_updated_at
+    before update on returns
+    for each row
+    execute procedure update_updated_at_column();

--- a/supabase/migrations/20260124_fix_alerts_rls.sql
+++ b/supabase/migrations/20260124_fix_alerts_rls.sql
@@ -1,0 +1,21 @@
+-- Enable Admins to view all product alerts (to trigger notifications)
+create policy "Admins can view all alerts"
+  on product_alerts for select
+  using (
+    exists (
+      select 1 from profiles
+      where profiles.id = auth.uid()
+      and profiles.role = 'admin'
+    )
+  );
+
+-- Enable Admins to update all product alerts (to mark as triggered)
+create policy "Admins can update all alerts"
+  on product_alerts for update
+  using (
+    exists (
+      select 1 from profiles
+      where profiles.id = auth.uid()
+      and profiles.role = 'admin'
+    )
+  );

--- a/supabase/migrations/20260124_notifications.sql
+++ b/supabase/migrations/20260124_notifications.sql
@@ -1,0 +1,43 @@
+-- Create notifications table
+create table notifications (
+  id uuid default gen_random_uuid() primary key,
+  user_id uuid references auth.users on delete cascade not null,
+  type text not null check (type in ('price_drop', 'restock', 'system')),
+  title text not null,
+  message text not null,
+  read boolean default false,
+  metadata jsonb default '{}'::jsonb,
+  created_at timestamp with time zone default timezone('utc'::text, now()) not null
+);
+
+-- Enable RLS
+alter table notifications enable row level security;
+
+-- RLS Policies
+
+-- Users can view their own notifications
+create policy "Users can view own notifications"
+  on notifications for select
+  using (auth.uid() = user_id);
+
+-- Users can update (mark as read) their own notifications
+create policy "Users can update own notifications"
+  on notifications for update
+  using (auth.uid() = user_id);
+
+-- Admins can create notifications (system wide) or service role
+-- We'll rely on service_role key for backend creation usually, 
+-- but allow admins to insert for testing if needed.
+create policy "Admins can insert notifications"
+  on notifications for insert
+  with check (
+    exists (
+      select 1 from profiles
+      where profiles.id = auth.uid()
+      and profiles.role = 'admin'
+    )
+  );
+
+-- Indexes
+create index notifications_user_id_idx on notifications(user_id);
+create index notifications_read_idx on notifications(read) where read = false;


### PR DESCRIPTION
## Summary\n- stabilize product filter handling to prevent duplicate RSC fetches and clean NotificationBell/init fetch\n- tighten chat/alerts/returns APIs and tools with proper typing, add notification/alert services and migrations\n- fix lint across tests and UI (OrderDetail date memo, tool tests, notification tests)\n\n## Testing\n- npm run lint\n- npm run test\n- npm run build