### PR TITLE
feat(rag): add query translation for semantic search

### DIFF
--- a/src/lib/ai/query-translator.test.ts
+++ b/src/lib/ai/query-translator.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { translateQuery } from './query-translator';
+import { generateText } from 'ai';
+
+// Mock the AI SDK
+vi.mock('ai', () => ({
+  generateText: vi.fn(),
+}));
+
+describe('translateQuery', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should translate Chinese query to English optimized for search', async () => {
+    (generateText as Mock).mockResolvedValue({
+      text: 'iPhone smartphone',
+    });
+
+    const result = await translateQuery('苹果手机');
+    expect(result).toBe('iPhone smartphone');
+    expect(generateText).toHaveBeenCalledTimes(1);
+    const callArgs = (generateText as Mock).mock.calls[0][0];
+    expect(callArgs.system).toContain('translate');
+    expect(callArgs.prompt).toBe('苹果手机');
+  });
+
+  it('should optimize English query', async () => {
+    (generateText as Mock).mockResolvedValue({
+      text: 'affordable oil painting',
+    });
+
+    const result = await translateQuery('cheap oil painting');
+    expect(result).toBe('affordable oil painting');
+  });
+
+  it('should return original query if API fails', async () => {
+    (generateText as Mock).mockRejectedValue(new Error('API Error'));
+
+    const result = await translateQuery('test query');
+    expect(result).toBe('test query');
+  });
+
+  it('should handle empty query', async () => {
+    const result = await translateQuery('');
+    expect(result).toBe('');
+    expect(generateText).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/ai/query-translator.ts
+++ b/src/lib/ai/query-translator.ts
@@ -1,0 +1,24 @@
+import { generateText } from 'ai';
+import { openai } from './openai';
+
+export async function translateQuery(query: string): Promise<string> {
+  if (!query) return '';
+
+  try {
+    const { text } = await generateText({
+      model: openai('gpt-4o'), // Or appropriate model
+      system: `You are a search query optimizer for an e-commerce store.
+Your goal is to convert the user's raw query into a concise, English, keyword-rich search term that will match product names and descriptions best.
+- If the query is in Chinese (or other languages), translate it to English.
+- If the query is vague, use more specific e-commerce keywords.
+- Remove conversational filler words.
+- Output ONLY the optimized query string, nothing else.`,
+      prompt: query,
+    });
+
+    return text.trim();
+  } catch (error) {
+    console.error('Query translation failed:', error);
+    return query; // Fallback to original query
+  }
+}

--- a/src/lib/search/products.test.ts
+++ b/src/lib/search/products.test.ts
@@ -5,6 +5,10 @@ vi.mock('@/lib/ai/embedding', () => ({
   generateEmbedding: vi.fn().mockResolvedValue([0.1, 0.2, 0.3])
 }))
 
+vi.mock('@/lib/ai/query-translator', () => ({
+  translateQuery: vi.fn(async (q) => `translated ${q}`)
+}))
+
 const mockRpc = vi.fn()
 const mockSupabase = {
   rpc: mockRpc
@@ -40,7 +44,7 @@ describe('searchProducts', () => {
     const result = await searchProducts('test query')
 
     expect(mockRpc).toHaveBeenCalledWith('match_products_hybrid', expect.objectContaining({
-      query_text: 'test query',
+      query_text: 'translated test query',
       match_count: 10
     }))
     


### PR DESCRIPTION
## Summary
Adds an LLM-based Query Translation step to the Semantic Search pipeline (`searchProducts`).

## Key Features
- **QueryTranslator Service**: Uses `gpt-4o` (via Vercel AI SDK) to translate/optimize user queries before searching.
  - Translates non-English queries to English (matching metadata).
  - Optimizes vague queries with e-commerce keywords.
- **Integration**:
  - `searchProducts` now calls `translateQuery` before generating embeddings.
  - The translated query is used for **both** Vector Search (embedding) and Hybrid Text Search (`query_text`).
- **Resilience**:
  - Fallback to original query if LLM translation fails.

## Verification
- Added `src/lib/ai/query-translator.test.ts` (100% coverage of translation logic).
- Updated `src/lib/search/products.test.ts` to verify integration.
- Updated `src/app/actions/product-actions.test.ts` to mock the new service (preventing test noise).